### PR TITLE
Fix uncaught DOMException at start

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const RESERVED_FILENAME_REGEX = getFileRegex()
 // this can be bad when multiple instances of this app are running
 if (typeof navigator !== 'undefined' && navigator.storage?.getDirectory) {
   navigator.storage.getDirectory().then(storageDir => {
-    storageDir.removeEntry('chunks', { recursive: true })
+    storageDir.removeEntry('chunks', { recursive: true }).catch(() => {})
   })
 }
 


### PR DESCRIPTION
Importing the package will trigger the snippet : 
```js
if (typeof navigator !== 'undefined' && navigator.storage?.getDirectory) {
  navigator.storage.getDirectory().then(storageDir => {
    storageDir.removeEntry('chunks', { recursive: true })
  })
}
```

This can, and will, trigger an error : `Uncaught (in promise) DOMException: Entry not found`, if `chunks` doesn't exists. I think the code is meant to clean this entry so if it doesn't exists we should skip the exception.